### PR TITLE
Spam detection sends flagged message to author

### DIFF
--- a/events/messageCreate.js
+++ b/events/messageCreate.js
@@ -25,6 +25,10 @@ module.exports = async function (message) {
         if (count[i] >= 10) flagged = true;
     });
     if (flagged) {
+        try {   
+            await message.author.send({content: `Your message has been flagged for spam:\n**"** ${message.content} **"**`});
+        } catch (e) {
+        }
         if (flaggedUsers.has(message.author.id)) {
             let flaggedAt = flaggedUsers.get(message.author.id);
             if ((forgetAfter * 1000) > Date.now() - flaggedAt) {


### PR DESCRIPTION
I wrote this functionality because it may be convenient for users to not irretrievably lose the message they've typed (without mod assistance), especially if it's simply too long to fit in one message.

Note: This code calls `User.send` on user text input.  I do not have much experience coding in JS or discord.js, so I'm not sure if this poses some sort of injection risk.  I would assume not.